### PR TITLE
[FEAT] Header 카테고리 메뉴 노출 기능 구현

### DIFF
--- a/FE/fe-sidedish/src/components/header/CategoryItems.jsx
+++ b/FE/fe-sidedish/src/components/header/CategoryItems.jsx
@@ -1,17 +1,20 @@
 import { Category, CategoryTitle, CategoryMenuList } from "./Header.style";
 import CategoryMenuItems from "./CategoryMenuItems";
 
-const CategoryItems = ({ categoriesData }) => {
-  return categoriesData.map(_getCategory);
+const CategoryItems = ({ isOpen, categoriesData }) => {
+  return categoriesData.map(_getCategory(isOpen));
 };
 
-const _getCategory = ({ id, categoryTitle, categoryMenus }) => (
-  <Category key={id}>
-    <CategoryTitle>{categoryTitle}</CategoryTitle>
-    <CategoryMenuList>
-      <CategoryMenuItems categoryMenus={categoryMenus} />
-    </CategoryMenuList>
-  </Category>
-);
+const _getCategory =
+  (isOpen) =>
+  ({ id, categoryTitle, categoryMenus }) =>
+    (
+      <Category key={id}>
+        <CategoryTitle>{categoryTitle}</CategoryTitle>
+        <CategoryMenuList isOpen={isOpen}>
+          {isOpen ? <CategoryMenuItems categoryMenus={categoryMenus} /> : ""}
+        </CategoryMenuList>
+      </Category>
+    );
 
 export default CategoryItems;

--- a/FE/fe-sidedish/src/components/header/Header.jsx
+++ b/FE/fe-sidedish/src/components/header/Header.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import iconMenusData from "../../data/iconMenus";
 import categoriesData from "../../data/categories";
 import HeaderTitle from "./HeaderTitle";
@@ -6,12 +7,24 @@ import IconMenuItems from "./IconMenuItems";
 import { Container, Wrapper, CategoryList, IconMenuList } from "./Header.style";
 
 const Header = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleMouseEnter = () => {
+    setIsOpen(true);
+  };
+  const handleMouseLeave = () => {
+    setIsOpen(false);
+  };
+
   return (
-    <Container>
+    <Container isOpen={isOpen}>
       <Wrapper>
-        <CategoryList>
-          <CategoryItems categoriesData={categoriesData} />
         <HeaderTitle title={"Ordering"} href={"/"} />
+        <CategoryList
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <CategoryItems isOpen={isOpen} categoriesData={categoriesData} />
         </CategoryList>
         <IconMenuList>
           <IconMenuItems iconMenusData={iconMenusData} />

--- a/FE/fe-sidedish/src/components/header/Header.jsx
+++ b/FE/fe-sidedish/src/components/header/Header.jsx
@@ -1,22 +1,17 @@
 import iconMenusData from "../../data/iconMenus";
 import categoriesData from "../../data/categories";
-import {
-  Container,
-  Wrapper,
-  Title,
-  CategoryList,
-  IconMenuList,
-} from "./Header.style";
+import HeaderTitle from "./HeaderTitle";
 import CategoryItems from "./CategoryItems";
 import IconMenuItems from "./IconMenuItems";
+import { Container, Wrapper, CategoryList, IconMenuList } from "./Header.style";
 
 const Header = () => {
   return (
     <Container>
       <Wrapper>
-        <Title>Ordering</Title>
         <CategoryList>
           <CategoryItems categoriesData={categoriesData} />
+        <HeaderTitle title={"Ordering"} href={"/"} />
         </CategoryList>
         <IconMenuList>
           <IconMenuItems iconMenusData={iconMenusData} />

--- a/FE/fe-sidedish/src/components/header/Header.style.js
+++ b/FE/fe-sidedish/src/components/header/Header.style.js
@@ -2,6 +2,8 @@ import styled from "styled-components";
 
 const Container = styled.header`
   border-bottom: 1px solid ${({ theme }) => theme.color.black};
+  height: ${({ isOpen }) => (isOpen ? "176px" : "97px")};
+  transition: all ease-out 0.1s;
 `;
 
 const Wrapper = styled.div`
@@ -24,7 +26,8 @@ const Title = styled.h2`
 `;
 
 const CategoryList = styled.ul`
-  margin: 20px auto 0 40px;
+  margin: 0 auto 0 20px;
+  padding: 20px 20px 8px;
   display: flex;
   gap: 24px;
 `;
@@ -44,26 +47,31 @@ const IconMenu = styled.li`
     height: 32px;
     font-size: 0;
     svg:hover {
-      filter: invert(58%) sepia(62%) saturate(1704%) hue-rotate(348deg)
-        brightness(103%) contrast(104%);
+      fill: ${({ theme }) => theme.color.orange};
+      transition: all ease-out 0.1s;
     }
   }
 `;
 
 const Category = styled.li``;
 
-const CategoryTitle = styled.span``;
+const CategoryTitle = styled.p`
+  margin: 0 0 12px;
+`;
 
 const CategoryMenuList = styled.ul`
-  margin: 12px 0 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  transition: all ease-out 0.2s;
 `;
 
 const CategoryMenu = styled.li`
   font-size: ${({ theme }) => theme.fontSize.small};
+
   a {
+    display: block;
     color: ${({ theme }) => theme.color.black};
     &:hover {
       color: ${({ theme }) => theme.color.orange};

--- a/FE/fe-sidedish/src/components/header/Header.style.js
+++ b/FE/fe-sidedish/src/components/header/Header.style.js
@@ -17,6 +17,10 @@ const Title = styled.h2`
   font-family: "Outfit";
   font-weight: ${({ theme }) => theme.fontWeight.heavy};
   font-size: ${({ theme }) => theme.fontSize.display};
+  a {
+    display: block;
+    color: ${({ theme }) => theme.color.black};
+  }
 `;
 
 const CategoryList = styled.ul`

--- a/FE/fe-sidedish/src/components/header/HeaderTitle.jsx
+++ b/FE/fe-sidedish/src/components/header/HeaderTitle.jsx
@@ -1,0 +1,14 @@
+import { Link } from "react-router-dom";
+import { Title } from "./Header.style";
+
+const HeaderTitle = ({ title, href }) => {
+  return (
+    <Title>
+      <Link to="/" onClick={() => (window.location.href = href)}>
+        {title}
+      </Link>
+    </Title>
+  );
+};
+
+export default HeaderTitle;


### PR DESCRIPTION
## 📃 Description

- [x] 유저가 MenuList에 마우스를 올리면 레이어가 아래로 확장된다.
- [x] 마우스가 MenuList 영역을 벗어나면 확장됐던 내용이 사라지고 원래대로 돌아간다.
- [x] 헤더 보완 - 로고를 클릭하면 홈화면이 리로드 된다.

## 📸 Screenshot
![header_close](https://user-images.githubusercontent.com/41741221/164580686-2c44a1dd-fcb8-43cd-9308-a025a5d82819.png)
![header_open](https://user-images.githubusercontent.com/41741221/164580688-e08ff07a-ea95-4576-a2d1-00e3a2d9dfc4.png)

